### PR TITLE
LIME-250 Update to common-express v0.0.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "axios": "0.27.2",
     "cfenv": "1.2.4",
     "connect-dynamodb": "^2.0.5",
-    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.38",
+    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.39",
     "dotenv": "^16.0.2",
     "express": "4.18.1",
     "express-async-errors": "^3.1.1",


### PR DESCRIPTION
## Proposed changes

Update to common-express v0.0.39 which brings the change to send the user’s language choice to Google Analytics.

### What changed

Common-express v0.0.39
Replicates the implementation found in core-front.

https://github.com/alphagov/di-ipv-core-front/commit/7feea5893e98b9b3083d5e8d14189100b1cd4d5a

https://github.com/alphagov/di-authentication-frontend/commit/74ebe4d7c64ea5643d387ee947dc0c6dc44eac5c

https://github.com/alphagov/di-ipv-core-front/pull/572

### Why did it change

To track users language choice.

### Issue tracking

- [LIME-250](https://govukverify.atlassian.net/browse/LIME-250)
- https://github.com/alphagov/di-ipv-cri-common-express/pull/168
 

[LIME-250]: https://govukverify.atlassian.net/browse/LIME-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ