### PR TITLE
FrontGatewayId as required by dns-records

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -718,5 +718,5 @@ Outputs:
   PassportFrontGatewayID:
     Description: Passport Front API Gateway ID
     Export:
-      Name: !Sub "PassportFrontApiGatewayID-${Environment}"
+      Name: !Sub "${AWS::StackName}-PassportFrontGatewayID"
     Value: !Ref ApiGwHttpEndpoint


### PR DESCRIPTION
## Proposed changes

### What changed

FrontGatewayId as required by dns-records

### Why did it change

Required in https://github.com/alphagov/di-ipv-cri-common-infrastructure/blob/main/dns-records/template.yaml#L115-L117

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PLAT-833](https://govukverify.atlassian.net/browse/PLAT-833)


[PLAT-833]: https://govukverify.atlassian.net/browse/PLAT-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ