### PR TITLE
LIME-409 Swap passport lambda paths with the common-cri-api paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test": "mocha",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",
     "test:watch": "mocha --watch",
-    "lint": "prettier --check src test && eslint ."
+    "lint": "prettier --check src test && eslint .",
+    "lint-apply": "prettier --write src test && eslint ."
   },
   "repository": {
     "type": "git",

--- a/src/app/passport/controllers/details.test.js
+++ b/src/app/passport/controllers/details.test.js
@@ -32,7 +32,6 @@ describe("details controller", () => {
 
     await details.saveValues(req, res, next);
 
-    const showRetryMessage = req.sessionModel.get("showRetryMessage");
-    expect(showRetryMessage).to.equal(false);
+    expect(req.sessionModel.get("showRetryMessage")).to.equal(false);
   });
 });

--- a/src/app/passport/fieldsHelper.js
+++ b/src/app/passport/fieldsHelper.js
@@ -15,6 +15,10 @@ module.exports = {
       : 0;
     const firstNameLength = validators.string(firstName) ? firstName.length : 0;
 
-    return middleNameLength + firstNameLength <= length;
+    const firstNameMin = firstNameLength > 0;
+    const middleNameMin = middleNameLength > 0;
+    const nameMin = firstNameMin || middleNameMin;
+
+    return nameMin && middleNameLength + firstNameLength <= length;
   },
 };

--- a/src/app/passport/fieldsHelper.test.js
+++ b/src/app/passport/fieldsHelper.test.js
@@ -32,4 +32,37 @@ describe("custom validation fields test", () => {
 
     expect(validator(1, 30, "firstName", "middleNames")).to.be.false;
   });
+
+  it("should be true when firstName is null but middleNames is valid", () => {
+    const validator = fields.firstNameMiddleNameLengthValidator.bind({
+      values: {
+        firstName: undefined,
+        middleNames: "jjjj",
+      },
+    });
+
+    expect(validator(1, 30, "firstName", "middleNames")).to.be.true;
+  });
+
+  it("should be true when middleNames is null but firstName is valid", () => {
+    const validator = fields.firstNameMiddleNameLengthValidator.bind({
+      values: {
+        firstName: "jjjj",
+        middleNames: undefined,
+      },
+    });
+
+    expect(validator(1, 30, "firstName", "middleNames")).to.be.true;
+  });
+
+  it("should be false when combined name is 0 characters", () => {
+    const validator = fields.firstNameMiddleNameLengthValidator.bind({
+      values: {
+        firstName: "",
+        middleNames: "",
+      },
+    });
+
+    expect(validator(1, 30, "firstName", "middleNames")).to.be.false;
+  });
 });

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -4,9 +4,9 @@ module.exports = {
   API: {
     BASE_URL: process.env.API_BASE_URL || "http://localhost:5007/",
     PATHS: {
-      SESSION: "initialise-session",
+      SESSION: "session",
       CHECK: "check-passport",
-      AUTHORIZATION: "build-client-oauth-response",
+      AUTHORIZATION: "authorization",
     },
   },
   APP: {


### PR DESCRIPTION
## Proposed changes

### What changed

Change the paths 
SESSION from initialise-session to session
AUTHORIZATION from build-client-oauth-response to authorization

Small addition to package.json to allow applying the prettier formatting rules needed to pass lint checks.

Modified/Added tests to bring coverage above 80%.

### Why did it change

These paths by convention follow the lambdas names behind the API gateway. These lambdas are now the common-api session and authorization lambdas, with the API gateways updated in https://github.com/alphagov/di-ipv-cri-uk-passport-api/pull/11

Pre-merge was failing due to coverage being under 80%.
Several tests cases for null/zero length fields where added.
In the test "should clear showRetryMessage in session", using a temporary variable in the expect was causing the coverage report for the code being tested to be calculated incorrectly.

### Issue tracking

- [LIME-409](https://govukverify.atlassian.net/browse/LIME-409)
https://github.com/alphagov/di-ipv-cri-uk-passport-api/pull/11


[LIME-409]: https://govukverify.atlassian.net/browse/LIME-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ