### PR TITLE
LIME-741: Fixing issue where s3 buckets can not be deployed with ACLs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -144,6 +144,9 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
 
   PassportFrontAccessLogsBucketPolicy:
     Condition: IsNotDevelopment


### PR DESCRIPTION
## Proposed changes

### What changed

Set ownership controls on s3 bucket

### Why did it change

In order to deploy s3 buckets with ACLs we must set ownernship. Only effects newstacks

