### PR TITLE
LIME-802 enable log group subscription filters

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -404,13 +404,13 @@ Resources:
       RetentionInDays: 14
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
-  # ECSAccessLogsGroupSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Condition: IsNotDevelopment
-  #   Properties:
-  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref ECSAccessLogsGroup
+  ECSAccessLogsGroupSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref ECSAccessLogsGroup
 
   ECSServiceTaskDefinition:
     Type: "AWS::ECS::TaskDefinition"
@@ -588,13 +588,13 @@ Resources:
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
       RetentionInDays: 14
 
-  # APIGWAccessLogsGroupSubscriptionFilterCSLS:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Condition: IsNotDevelopment
-  #   Properties:
-  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref APIGWAccessLogsGroup
+  APIGWAccessLogsGroupSubscriptionFilterCSLS:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref APIGWAccessLogsGroup
 
   LoggingKmsKey:
     Type: AWS::KMS::Key


### PR DESCRIPTION
## Proposed changes

### What changed

Uncommented the log group subscription filters  

### Why did it change

To enable front end logs to be forwarded

### Issue tracking

- [LIME-802](https://govukverify.atlassian.net/browse/LIME-802)



[LIME-802]: https://govukverify.atlassian.net/browse/LIME-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ