### PR TITLE
LIME-803 Correcting firstname middlename bug

### DIFF
--- a/src/app/passport/fieldsHelper.js
+++ b/src/app/passport/fieldsHelper.js
@@ -9,17 +9,17 @@ module.exports = {
   ) {
     const firstName = this.values[firstNameField];
     const middleName = this.values[middleNameField];
-    const middleNameEmpty = !validators.string(middleName);
-    const firstNameEmpty = !validators.string(firstName);
-    const includeExtraCharacter = !middleNameEmpty && !firstNameEmpty;
-    const extraCharacter = includeExtraCharacter ? 1 : 0;
-    //This logic will add an extra character to nameMax (see below) if both first and
-    //middle name fields are used, in order to ensure we remain within 30 characters limit
 
     const middleNameLength = validators.string(middleName)
       ? middleName.length
       : 0;
     const firstNameLength = validators.string(firstName) ? firstName.length : 0;
+
+    const singleName = firstNameLength === 0 || middleNameLength === 0;
+
+    const extraCharacter = singleName ? 0 : 1;
+    //This logic will add an extra character to nameMax (see below) if both first and
+    //middle name fields are used, in order to ensure we remain within 30 characters limit
 
     const firstNameMin = firstNameLength > 0;
     const middleNameMin = middleNameLength > 0;

--- a/src/app/passport/fieldsHelper.test.js
+++ b/src/app/passport/fieldsHelper.test.js
@@ -36,7 +36,7 @@ describe("firstName middleNames validation fields test", () => {
   it("should be true when firstName is null but middleNames is valid", () => {
     const validator = fields.firstNameMiddleNameLengthValidator.bind({
       values: {
-        firstName: undefined,
+        firstName: "",
         middleNames: "jjjj",
       },
     });
@@ -48,7 +48,7 @@ describe("firstName middleNames validation fields test", () => {
     const validator = fields.firstNameMiddleNameLengthValidator.bind({
       values: {
         firstName: "jjjj",
-        middleNames: undefined,
+        middleNames: "",
       },
     });
 
@@ -65,6 +65,28 @@ describe("firstName middleNames validation fields test", () => {
 
     expect(validator(1, 30, "firstName", "middleNames")).to.be.false;
   });
+
+  it("should be true when first and middle name combined is 28 characters", () => {
+    const validator = fields.firstNameMiddleNameLengthValidator.bind({
+      values: {
+        firstName: "jjjjjjjjjjjjjjjjjjj",
+        middleNames: "jjjjjjjjj",
+      },
+    });
+
+    expect(validator(1, 30, "firstName", "middleNames")).to.be.true;
+  });
+
+  it("should be true when first and middle name plus extra character combined is 29 characters", () => {
+    const validator = fields.firstNameMiddleNameLengthValidator.bind({
+      values: {
+        firstName: "jjjjjjjjjjjjjjjjjjjj",
+        middleNames: "jjjjjjjjj",
+      },
+    });
+
+    expect(validator(1, 30, "firstName", "middleNames")).to.be.true;
+  });
   it("should be false when first and middle name combined is 30 characters", () => {
     const validator = fields.firstNameMiddleNameLengthValidator.bind({
       values: {
@@ -75,31 +97,12 @@ describe("firstName middleNames validation fields test", () => {
 
     expect(validator(1, 30, "firstName", "middleNames")).to.be.false;
   });
-  it("should be false when first and middle name combined is 31 characters", () => {
-    const validator = fields.firstNameMiddleNameLengthValidator.bind({
-      values: {
-        firstName: "jjjjjjjjjjjjjjjjjjjj",
-        middleNames: "jjjjjjjjjjj",
-      },
-    });
 
-    expect(validator(1, 30, "firstName", "middleNames")).to.be.false;
-  });
-  it("should be true when first and middle name combined is 29 characters", () => {
-    const validator = fields.firstNameMiddleNameLengthValidator.bind({
-      values: {
-        firstName: "jjjjjjjjjjjjjjjjjjj",
-        middleNames: "jjjjjjjjjj",
-      },
-    });
-
-    expect(validator(1, 30, "firstName", "middleNames")).to.be.true;
-  });
   it("should be true when first name is 30 characters and middle names is null", () => {
     const validator = fields.firstNameMiddleNameLengthValidator.bind({
       values: {
         firstName: "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjj",
-        middleNames: undefined,
+        middleNames: "",
       },
     });
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Correcting firstname middlename calculation

### Why did it change

Incorrectly allowing 30 characters to pass if sent as first name and middle name

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-803](https://govukverify.atlassian.net/browse/LIME-803)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-803]: https://govukverify.atlassian.net/browse/LIME-803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ