### PR TITLE
LIME-1637 - Passport FE - Split out Axe Scan into Specific Tests for better visibility 

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "@cucumber/cucumber": "10.0.1",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.15.0",
-    "@playwright/test": "1.48.2",
     "axe-playwright": "2.1.0",
+    "@playwright/test": "1.51.1",
     "chai": "4.5.0",
     "chai-as-promised": "7.1.1",
     "copyfiles": "2.4.1",
@@ -67,8 +67,8 @@
     "sinon": "19.0.2",
     "sinon-chai": "3.7.0",
     "uglify-js": "3.19.3",
-    "wait-on": "8.0.1",
-    "wiremock": "^2.33.2"
+    "wait-on": "8.0.2",
+    "wiremock": "3.12.1"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.731.1",

--- a/test/browser/features/passport/Passport.feature
+++ b/test/browser/features/passport/Passport.feature
@@ -316,3 +316,18 @@ Feature: Passport CRI - Happy Path and Field Valisation Tests
     Examples:
       | DeviceIntelligenceCookieName |
       | di-device-intelligence       |
+  @mock-api:passport-success @Passport_test @build @staging @integration
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Passport Details Page
+    Given I run the Axe Accessibility check against the Passport details entry page
+    Then User enters passport data as a <PassportSubject>
+    When User clicks on continue
+    Examples:
+      | PassportSubject             |
+      | PassportSubjectHappyKenneth |
+
+  @mock-api:passport-success @Passport_test @build @staging @integration
+  Scenario: Passport CRI - Axe Accessibility Scan - Passport Error Page
+    Given I delete the session cookie
+    And User clicks on continue
+    Then they should see an error page
+    Then I run the Axe Accessibility check against the Error entry page

--- a/test/browser/step_definitions/PassportStepDefs.js
+++ b/test/browser/step_definitions/PassportStepDefs.js
@@ -13,14 +13,20 @@ Then(
   async function (PassportPageTitle) {
     const passportPage = new PassportPage(this.page);
     await passportPage.assertPageTitle(PassportPageTitle);
+  }
+);
+
+Given(
+  /^I run the Axe Accessibility check against the Passport details entry page$/,
+  async function () {
     await injectAxe(this.page);
     // Run Axe for WCAG 2.2 AA rules
     const wcagResults = await this.page.evaluate(() => {
       return axe.run({
-        runOnly: ["wcag2aa"]
+        runOnly: ["wcag22aa"]
       });
     });
-    expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
+    expect(wcagResults.violations).to.be.empty;
   }
 );
 

--- a/test/browser/step_definitions/errors.js
+++ b/test/browser/step_definitions/errors.js
@@ -8,19 +8,22 @@ const { injectAxe } = require("axe-playwright");
 
 Then("they should see an error page", async function () {
   const errorPage = new ErrorPage(this.page);
-
   const errorTitle = await errorPage.getErrorTitle();
-
-  await injectAxe(this.page);
-  // Run Axe for WCAG 2.2 AA rules
-  const wcagResults = await this.page.evaluate(() => {
-    return axe.run({
-      runOnly: ["wcag2aa"]
-    });
-  });
-  expect(wcagResults.violations, "WCAG 2.2 AAA violations found").to.be.empty;
-
   expect(errorTitle.trim()).to.equal(
     errorPage.getSomethingWentWrongMessage().trim()
   );
 });
+
+Then(
+  "I run the Axe Accessibility check against the Error entry page",
+  async function () {
+    await injectAxe(this.page);
+    // Run Axe for WCAG 2.2 AA rules
+    const wcagResults = await this.page.evaluate(() => {
+      return axe.run({
+        runOnly: ["wcag21aa"]
+      });
+    });
+    expect(wcagResults.violations).to.be.empty;
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,12 +1050,12 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
-"@playwright/test@1.48.2":
-  version "1.48.2"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.48.2.tgz#87dd40633f980872283404c8142a65744d3f13d6"
-  integrity sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==
+"@playwright/test@1.51.1":
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.51.1.tgz#75357d513221a7be0baad75f01e966baf9c41a2e"
+  integrity sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==
   dependencies:
-    playwright "1.48.2"
+    playwright "1.51.1"
 
 "@redis/bloom@1.2.0":
   version "1.2.0"
@@ -1882,7 +1882,7 @@ ajv-keywords@^5.1.0:
 
 ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
@@ -2121,10 +2121,10 @@ axios@1.8.2:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^1.7.7:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
-  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
+axios@^1.7.9:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"
@@ -5543,10 +5543,10 @@ playwright-core@1.32.3:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.32.3.tgz#e6dc7db0b49e9b6c0b8073c4a2d789a96f519c48"
   integrity sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==
 
-playwright-core@1.48.2:
-  version "1.48.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.48.2.tgz#cd76ed8af61690edef5c05c64721c26a8db2f3d7"
-  integrity sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==
+playwright-core@1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.51.1.tgz#d57f0393e02416f32a47cf82b27533656a8acce1"
+  integrity sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==
 
 playwright@1.32.3:
   version "1.32.3"
@@ -5555,12 +5555,12 @@ playwright@1.32.3:
   dependencies:
     playwright-core "1.32.3"
 
-playwright@1.48.2:
-  version "1.48.2"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.48.2.tgz#fca45ae8abdc34835c715718072aaff7e305167e"
-  integrity sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==
+playwright@1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.51.1.tgz#ae1467ee318083968ad28d6990db59f47a55390f"
+  integrity sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==
   dependencies:
-    playwright-core "1.48.2"
+    playwright-core "1.51.1"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -5988,9 +5988,9 @@ run-parallel@^1.1.9:
     queue-microtask "^1.2.2"
 
 rxjs@^7.8.1:
-  version "7.8.1"
-  resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz"
-  integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
   dependencies:
     tslib "^2.1.0"
 
@@ -6327,7 +6327,7 @@ sort-object-keys@^1.1.3:
 
 source-map-support@0.5.21, source-map-support@^0.5.21, source-map-support@~0.5.20:
   version "0.5.21"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
@@ -6906,12 +6906,12 @@ verror@^1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-wait-on@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-8.0.1.tgz#13c8ec77115517f8fbc2d670521a444201f03f53"
-  integrity sha512-1wWQOyR2LVVtaqrcIL2+OM+x7bkpmzVROa0Nf6FryXkS+er5Sa1kzFGjzZRqLnHa3n1rACFLeTwUqE1ETL9Mig==
+wait-on@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-8.0.2.tgz#0c7929abf7c5e625b733e992a9c0bd8b7691afe3"
+  integrity sha512-qHlU6AawrgAIHlueGQHQ+ETcPLAauXbnoTKl3RKq20W0T8x0DKVAo5xWIYjHSyvHxQlcYbFdR0jp4T9bDVITFA==
   dependencies:
-    axios "^1.7.7"
+    axios "^1.7.9"
     joi "^17.13.3"
     lodash "^4.17.21"
     minimist "^1.2.8"
@@ -7008,10 +7008,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wiremock@^2.33.2:
-  version "2.35.1"
-  resolved "https://registry.yarnpkg.com/wiremock/-/wiremock-2.35.1.tgz#45a5cd2c7a50d85744256ae6662397330d5199f1"
-  integrity sha512-GTrJ6Ss9iyqxar3JHrr6PgdRaP5WxwYsKq+zeO2CwE1AOfYZ38s2usjyCXKeDlqtvkKEytHsa9AggPqDvva09Q==
+wiremock@3.12.1:
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/wiremock/-/wiremock-3.12.1.tgz#44ff95c8edffeb24c0fd15a7929b9b766a1bc526"
+  integrity sha512-gEJOzFuQTh4emP/bfHPAhL9qLv6LBVn72/jSQKPzNesbp0TT+a/Gx3cSzm0Gc1AGX+WVZ5zFKKemZYMFpqp0mQ==
   dependencies:
     npm-java-runner "^1.0.2"
 


### PR DESCRIPTION

## Proposed changes
Updated Axe Accessibility Tests:

### What changed
Removed the Axe Scan from the background step of the Scenarios and within Error Page Step Added Specific Test for Passport Details Page and Passport Error Page which runs the Axe Scan

### Why did it change
This will allow for clearer reporting and troubleshooting of any accessibility issues going forward

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->





<!-- Describe the changes in detail - the "what"-->



<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1637](https://govukverify.atlassian.net/browse/LIME-1637)

### Other considerations

Test Results Local: 

![image](https://github.com/user-attachments/assets/a0dae9df-1579-4f86-b30e-2a3f4822c25a)



[LIME-1637]: https://govukverify.atlassian.net/browse/LIME-1637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ