### PR TITLE
LIME-1720: Adding skipLink to default yaml.

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -7,6 +7,7 @@ govuk:
   errorSummaryTitle: "Mae problem"
   error: "Gwall"
   warning: "Rhybudd"
+  skipLink: "Neidio i’r prif gynnwys"
 
 passport:
   title: "Rhowch eich manylion yn union fel maent yn ymddangos ar eich pasbort y DU"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -7,6 +7,7 @@ govuk:
   errorSummaryTitle: There’s a problem
   error: Error
   warning: Warning
+  skipLink: Skip to main content
 
 passport:
   title: Enter your details exactly as they appear on your UK passport


### PR DESCRIPTION
### What changed

Added back the skipLink that was removed as part of removing the redundant fields in default yaml.

### Issue tracking

- [LIME-1720](https://govukverify.atlassian.net/browse/LIME-1720)

[LIME-1720]: https://govukverify.atlassian.net/browse/LIME-1720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ