### PR TITLE
LIME-1825 - Added new Test for 'skip to main content' link and text

### DIFF
--- a/test/browser/features/passport/Passport.feature
+++ b/test/browser/features/passport/Passport.feature
@@ -19,6 +19,11 @@ Feature: Passport CRI - Happy Path and Field Valisation Tests
     Given The Support link in the footer reads Support (opens in new tab)
     And I assert the support link url in the footer is correct and live
 
+  @mock-api:passport-success @passport-happy-path
+  Scenario: Passport CRI - Skip to Main Content
+    Given I should be on the Passport details entry page Enter your details exactly as they appear on your UK passport – GOV.UK One Login
+    Then I see the Skip to main content Link Text
+
   ########### Page UI Elements (Links) ##########
 
   @mock-api:passport-success @passport-page-element-validation

--- a/test/browser/pages/PassportPage.js
+++ b/test/browser/pages/PassportPage.js
@@ -9,6 +9,8 @@ exports.PassportPage = class PlaywrightDevPage {
 
     this.passportNumber = this.page.locator('xpath=//*[@id="passportNumber"]');
 
+    this.skipToMainContent = this.page.locator("xpath=//html/body/a");
+
     this.lastName = this.page.locator('xpath=//*[@id="surname"]');
     this.firstName = this.page.locator('xpath=//*[@id="firstName"]');
     this.middleNames = this.page.locator('xpath=//*[@id="middleNames"]');
@@ -495,7 +497,14 @@ exports.PassportPage = class PlaywrightDevPage {
     );
   }
 
-  //  Language
+  async assertSkipToMainContent(skipToMainContent) {
+    await this.page.waitForLoadState("domcontentloaded");
+    await this.skipToMainContent.textContent(skipToMainContent);
+    expect(await this.skipToMainContent.textContent()).to.contains(
+      skipToMainContent
+    );
+  }
+
   async assertBetaBanner(betaBannerLabel) {
     await this.page.waitForLoadState("domcontentloaded");
     expect(await this.isCurrentPage()).to.be.true;

--- a/test/browser/step_definitions/PassportStepDefs.js
+++ b/test/browser/step_definitions/PassportStepDefs.js
@@ -464,6 +464,11 @@ Then(/^I can see year as (.*)$/, async function (year) {
   await passportPage.assertDobYearLabel(year);
 });
 
+Then(/^I see the (.*) Link Text$/, async function (skipToMainContent) {
+  const passportPage = new PassportPage(this.page);
+  await passportPage.assertSkipToMainContent(skipToMainContent);
+});
+
 Given(
   /^The Support link in the footer reads (.*)$/,
   async function (supportFooterLink) {


### PR DESCRIPTION
New Test added for the Skip to Main Content Link to validate it has the correct Text values (in relation to the work completed in LIME-1721)


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1825](https://govukverify.atlassian.net/browse/LIME-1825)

- [LIME-1721](https://govukverify.atlassian.net/browse/LIME-1721)

### Other considerations

All tests passing locally:

![Uploading image.png…]()



[LIME-1825]: https://govukverify.atlassian.net/browse/LIME-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1721]: https://govukverify.atlassian.net/browse/LIME-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ