### PR TITLE
LIME-1719: Updating README to MAY_2025_REBRAND_ENABLED defaults to fa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repo has a `CODEOWNERS` file in the root and is configured to require PRs t
 - `GA4_ENABLED` - BOOLEAN
 - `UA_ENABLED` - BOOLEAN
 - `LANGUAGE_TOGGLE_DISABLED` - Feature flag to disable Language Toggle, defaulted to `true`
-- `MAY_2025_REBRAND_ENABLED` - Feature flag to enable the May 2025 GOV.UK branding change, defaults to `true`
+- `MAY_2025_REBRAND_ENABLED` - Feature flag to enable the May 2025 GOV.UK branding change, defaults to `false`
 
 ## Local Testing
 


### PR DESCRIPTION
### What changed

README now indicates that MAY_2025_REBRAND_ENABLED feature flag defaults to false.

### Issue tracking

- [LIME-1719](https://govukverify.atlassian.net/browse/LIME-1719)


[LIME-1719]: https://govukverify.atlassian.net/browse/LIME-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ