### PR TITLE
LIME-2125 remove wait-on from devdeps

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -64,3 +64,4 @@ jobs:
           template-file: deploy/template.yaml
           role-to-assume-arn: ${{ secrets.AWS_DEV_DEPLOY_PASSPORTA_FRONT_GITHUB_ACTIONS_ROLE_ARN }}
           ecr-repo-name: ${{ secrets.AWS_DEV_DEPLOY_PASSPORTA_FRONT_DEV_ECR_REPOSITORY }}
+          docker-platform: linux/amd64

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -64,10 +64,6 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: yarn playwright install chromium --with-deps
 
-      - name: Setup Playwright dependencies
-        run: yarn playwright install-deps chromium
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-
       - name: Build assets
         run: yarn build
 

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -66,3 +66,4 @@ jobs:
           template-file: deploy/template.yaml
           role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           ecr-repo-name: ${{ secrets.ECR_REPOSITORY }}
+          docker-platform: linux/amd64

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -27,6 +27,9 @@
       "name": "GitHubTokenDetector"
     },
     {
+      "name": "GitLabTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -35,6 +38,9 @@
     },
     {
       "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -50,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -68,16 +80,15 @@
       "name": "StripeDetector"
     },
     {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
       "name": "TwilioKeyDetector"
     }
   ],
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -112,139 +123,139 @@
     }
   ],
   "results": {
-    ".yarn/releases/yarn-1.22.17.cjs": [
+    ".yarn/releases/yarn-1.22.22.cjs": [
       {
         "type": "Base64 High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "fd8201493aad9512bb25129219813806e68b2c51",
         "is_verified": false,
-        "line_number": 64929
+        "line_number": 64941
       },
       {
         "type": "Secret Keyword",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "b1a741d28b1d949ef6184bac2f63e97782793c11",
         "is_verified": false,
-        "line_number": 87109
+        "line_number": 87653
       },
       {
         "type": "Secret Keyword",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "6eb3665ce1c18c0a5de76163e7604dfa4a103ae7",
         "is_verified": false,
-        "line_number": 105083
+        "line_number": 101534
       },
       {
         "type": "Secret Keyword",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "9ef7320615f9c05bad1ea6ad1365104507871d7f",
         "is_verified": false,
-        "line_number": 105085
+        "line_number": 101536
       },
       {
         "type": "Secret Keyword",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "2287eee32aafc3bc835fcdd2214bf070725160f9",
         "is_verified": false,
-        "line_number": 105097
+        "line_number": 101548
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "10684db52c27b4692a4ee51ef75a1d5234069c53",
         "is_verified": false,
-        "line_number": 111993
+        "line_number": 108444
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "7c9ddb05834fa9e6c06ef9d948eb8e1a73881031",
         "is_verified": false,
-        "line_number": 111994
+        "line_number": 108445
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "02dea585f59babe05225954c8d1fdec196a1baec",
         "is_verified": false,
-        "line_number": 112008
+        "line_number": 108459
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "07d36c201d5f903272b769508b29de6bfc474556",
         "is_verified": false,
-        "line_number": 112009
+        "line_number": 108460
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "f6de6313ace4093d98c0aea3ddb1a7a733b058e6",
         "is_verified": false,
-        "line_number": 112023
+        "line_number": 108474
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "332e2126e121cf2048b5a1903f864df144047773",
         "is_verified": false,
-        "line_number": 112024
+        "line_number": 108475
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "6c9aafdcceb33bbcfd232f40afdb3298eb2c8b03",
         "is_verified": false,
-        "line_number": 112038
+        "line_number": 108489
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "f8692127a363c0b90301c1f9b9713a130eb23685",
         "is_verified": false,
-        "line_number": 112039
+        "line_number": 108490
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "32358b0b40f22e5aa4d70e9d0af6cf156840ee38",
         "is_verified": false,
-        "line_number": 112053
+        "line_number": 108504
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "46798dc6618143b34916eb0e8b3e653b368f7469",
         "is_verified": false,
-        "line_number": 112054
+        "line_number": 108505
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "9ed5e5eb0104bf6b3aecf69b389c289b3dca8261",
         "is_verified": false,
-        "line_number": 112068
+        "line_number": 108519
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "de3227cfb3b4dcdee04c35b442308cbc451d7424",
         "is_verified": false,
-        "line_number": 112069
+        "line_number": 108520
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "10bf5f5bab05c99283d3d3cd1c3da4ead81b48c5",
         "is_verified": false,
-        "line_number": 112083
+        "line_number": 108534
       },
       {
         "type": "Hex High Entropy String",
-        "filename": ".yarn/releases/yarn-1.22.17.cjs",
+        "filename": ".yarn/releases/yarn-1.22.22.cjs",
         "hashed_secret": "df4bff4de4289a6c92aea9d5f068158c89d4ae4b",
         "is_verified": false,
-        "line_number": 112084
+        "line_number": 108535
       }
     ],
     "deploy/template.yaml": [
@@ -285,5 +296,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-16T15:15:34Z"
+  "generated_at": "2026-04-13T15:42:44Z"
 }

--- a/.yarnrc
+++ b/.yarnrc
@@ -2,5 +2,5 @@
 # yarn lockfile v1
 
 
-yarn-path ".yarn/releases/yarn-1.22.17.cjs"
 ignore-scripts true
+yarn-path ".yarn/releases/yarn-1.22.22.cjs"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,0 @@
-nodeLinker: node-modules
-
-yarnPath: .yarn/releases/yarn-1.22.17.cjs
-ignore-scripts: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM node:22.16.0-alpine3.21@sha256:4437d7c27c4b9306c577caa17577dc7b367fc320fb7469dbe2c994e23b11d11c AS builder
+FROM node:22.16.0-alpine3.21@sha256:9f3ae04faa4d2188825803bf890792f33cc39033c9241fc6bb201149470436ca AS builder
 WORKDIR /app
-RUN [ "yarn", "set", "version", "1.22.17" ]
 COPY .yarn ./.yarn
 COPY /src ./src
 COPY package.json yarn.lock .yarnrc ./
@@ -13,12 +12,11 @@ RUN yarn build
 RUN [ "rm", "-rf", "node_modules" ]
 RUN yarn install --production --frozen-lockfile
 
-FROM node:22.16.0-alpine3.21@sha256:4437d7c27c4b9306c577caa17577dc7b367fc320fb7469dbe2c994e23b11d11c AS final
+FROM node:22.16.0-alpine3.21@sha256:9f3ae04faa4d2188825803bf890792f33cc39033c9241fc6bb201149470436ca AS final
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 
 RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "add", "--no-cache", "tini", "curl"]
-RUN ["yarn", "set", "version", "1.22.17" ]
 USER appuser:appgroup
 
 WORKDIR /app
@@ -31,9 +29,9 @@ COPY --chown=appuser:appgroup  --from=builder /app/yarn.lock ./
 
 # Add in dynatrace layer
 COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
-ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+ENV LD_PRELOAD=/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
-ENV PORT 8080
+ENV PORT=8080
 
 HEALTHCHECK --interval=5s --timeout=2s --retries=10 \
   CMD curl -f http://localhost:8080/healthcheck || exit 1
@@ -41,5 +39,3 @@ HEALTHCHECK --interval=5s --timeout=2s --retries=10 \
 EXPOSE 8080
 
 ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=PASSPORT-FRONT-$RANDOM && tini npm start"]
-
-CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 RUN [ "yarn", "set", "version", "1.22.17" ]
 COPY .yarn ./.yarn
 COPY /src ./src
-COPY package.json yarn.lock .yarnrc.yml ./
+COPY package.json yarn.lock .yarnrc ./
 
 RUN yarn install --frozen-lockfile
 RUN yarn build

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ const compat = new FlatCompat({
 export default [
   {
     ignores: [
+      "scripts/**/*.js",
       "src/app.test.js",
       "src/app-setup.test.js",
       "**/dist",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "prettier --check --no-editorconfig src test && eslint .",
     "lint-apply": "prettier --write src test && eslint .",
     "mocks": "yarn run wiremock --port 8050 --root-dir test/mocks",
-    "test:browser": "mkdir -p reports && wait-on tcp:127.0.0.1:8050 tcp:127.0.0.1:5050 && API_BASE_URL=http://127.0.0.1:8050/ MOCK_API=true cucumber-js --config test/browser/cucumber.js --profile wiremock_tests",
+    "test:browser": "mkdir -p reports && node scripts/wait-for-ports.js 127.0.0.1:8050 127.0.0.1:5050 && API_BASE_URL=http://127.0.0.1:8050/ MOCK_API=true cucumber-js --config test/browser/cucumber.js --profile wiremock_tests",
     "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser",
     "test:browser:stub": "mkdir -p reports && dotenv -e .env -- cucumber-js --config test/browser/cucumber.js --profile stub_tests",
     "test:browser:stub:ci": "npm-run-all -p -r test:browser:stub",
@@ -41,7 +41,7 @@
     "url": "https://github.com/alphagov/di-ipv-cri-uk-passport-front-v1/issues"
   },
   "homepage": "https://github.com/alphagov/di-ipv-cri-uk-passport-front-v1#readme",
-  "packageManager": "yarn@2.4.3",
+  "packageManager": "yarn@1.22.22",
   "devDependencies": {
     "@axe-core/playwright": "4.11.1",
     "@cucumber/cucumber": "12.7.0",
@@ -67,7 +67,6 @@
     "sinon": "21.1.0",
     "sinon-chai": "4.0.1",
     "uglify-js": "3.19.3",
-    "wait-on": "9.0.4",
     "wiremock": "3.13.2"
   },
   "dependencies": {
@@ -95,7 +94,6 @@
     "nyc/@istanbuljs/load-nyc-config/js-yaml": "4.1.1",
     "nyc/yargs/cliui/wrap-ansi": "7.0.0",
     "mocha/serialize-javascript": "7.0.5",
-    "wait-on/axios": "1.13.5",
     "hmpo-form-wizard/hmpo-model/http-proxy-agent/@tootallnate/once": "3.0.1",
     "mocha/diff": "8.0.3"
   }

--- a/scripts/wait-for-ports.js
+++ b/scripts/wait-for-ports.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// simple script to replace 'wait-on' dependency
+// usage: node scripts/wait-for-ports.js host:port [host:port ...]
+
+const net = require("node:net");
+
+const POLL_INTERVAL_MS = 500;
+const TIMEOUT_MS = 60_000;
+
+function awaitHostPort(host, port) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + TIMEOUT_MS;
+
+    function attempt() {
+      if (Date.now() > deadline) {
+        return reject(new Error(`Timed out waiting for ${host}:${port}`));
+      }
+      const socket = net.createConnection(port, host);
+      socket.on("connect", () => {
+        socket.destroy();
+        console.log(`ready: ${host}:${port}`);
+        resolve();
+      });
+      socket.on("error", () => {
+        socket.destroy();
+        setTimeout(attempt, POLL_INTERVAL_MS);
+      });
+    }
+
+    attempt();
+  });
+}
+
+const targets = process.argv.slice(2);
+if (targets.length === 0) {
+  console.error("usage: node scripts/wait-for-ports.js host:port [host:port ...]");
+  process.exit(1);
+}
+
+Promise.all(
+  targets.map((address) => {
+    const lastColon = address.lastIndexOf(":");
+    const host = address.slice(0, lastColon);
+    const port = Number(address.slice(lastColon + 1));
+    return awaitHostPort(host, port);
+  }),
+).catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,40 +1245,6 @@
   dependencies:
     pino "^8.21.0"
 
-"@hapi/address@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/address/-/address-5.1.1.tgz#e9925fc1b65f5cc3fbea821f2b980e4652e84cb6"
-  integrity sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==
-  dependencies:
-    "@hapi/hoek" "^11.0.2"
-
-"@hapi/formula@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@hapi/formula/-/formula-3.0.2.tgz#81b538060ee079481c906f599906d163c4badeaf"
-  integrity sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==
-
-"@hapi/hoek@^11.0.2", "@hapi/hoek@^11.0.7":
-  version "11.0.7"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-11.0.7.tgz#56a920793e0a42d10e530da9a64cc0d3919c4002"
-  integrity sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==
-
-"@hapi/pinpoint@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@hapi/pinpoint/-/pinpoint-2.0.1.tgz#32077e715655fc00ab8df74b6b416114287d6513"
-  integrity sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==
-
-"@hapi/tlds@^1.1.1":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@hapi/tlds/-/tlds-1.1.6.tgz#c98ed89ca76aa030352d6d7102d0f250aed89cfb"
-  integrity sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==
-
-"@hapi/topo@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-6.0.2.tgz#f219c1c60da8430228af4c1f2e40c32a0d84bbb4"
-  integrity sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==
-  dependencies:
-    "@hapi/hoek" "^11.0.2"
-
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"
@@ -2288,11 +2254,6 @@
   dependencies:
     tslib "^2.6.2"
 
-"@standard-schema/spec@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
-  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
-
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
@@ -2752,15 +2713,6 @@ axe-core@~4.11.1:
   version "4.11.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.11.2.tgz#86d28e085b170a4b43d459aee6d30624fba9be4e"
   integrity sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==
-
-axios@1.13.5, axios@^1.13.5:
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
-  integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
-  dependencies:
-    follow-redirects "^1.15.11"
-    form-data "^4.0.5"
-    proxy-from-env "^1.1.0"
 
 axios@1.15.0:
   version "1.15.0"
@@ -4871,19 +4823,6 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-joi@^18.0.2:
-  version "18.1.2"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-18.1.2.tgz#4735a384d7721fcda7a551d128862cf816541924"
-  integrity sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==
-  dependencies:
-    "@hapi/address" "^5.1.1"
-    "@hapi/formula" "^3.0.2"
-    "@hapi/hoek" "^11.0.7"
-    "@hapi/pinpoint" "^2.0.1"
-    "@hapi/tlds" "^1.1.1"
-    "@hapi/topo" "^6.0.2"
-    "@standard-schema/spec" "^1.1.0"
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5027,7 +4966,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
-lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.23:
+lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.23"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
   integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
@@ -5200,7 +5139,7 @@ minimatch@^9.0.4, minimatch@^9.0.5:
   dependencies:
     brace-expansion "^2.0.2"
 
-minimist@^1.2.6, minimist@^1.2.8:
+minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -5887,11 +5826,6 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
-
 proxy-from-env@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
@@ -6161,13 +6095,6 @@ rndm@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/rndm/-/rndm-1.2.0.tgz#f33fe9cfb52bbfd520aa18323bc65db110a1b76c"
   integrity sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw==
-
-rxjs@^7.8.2:
-  version "7.8.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
-  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
-  dependencies:
-    tslib "^2.1.0"
 
 safe-array-concat@^1.1.3:
   version "1.1.3"
@@ -6547,7 +6474,16 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6614,7 +6550,14 @@ string_decoder@^1.3.0:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6792,7 +6735,7 @@ ts-dedent@^2.0.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.6.2:
+tslib@^2.0.3, tslib@^2.6.2:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -7003,17 +6946,6 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-wait-on@9.0.4:
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-9.0.4.tgz#ddf3a44ebd18f380621855d52973069ff2cb5b54"
-  integrity sha512-k8qrgfwrPVJXTeFY8tl6BxVHiclK11u72DVKhpybHfUL/K6KM4bdyK9EhIVYGytB5MJe/3lq4Tf0hrjM+pvJZQ==
-  dependencies:
-    axios "^1.13.5"
-    joi "^18.0.2"
-    lodash "^4.17.23"
-    minimist "^1.2.8"
-    rxjs "^7.8.2"
-
 watchpack@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.5.1.tgz#dd38b601f669e0cbf567cb802e75cead82cde102"
@@ -7147,7 +7079,16 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@7.0.0, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

- replaced `wait-on` with simple script
- removed `wait-on` and related resolutions
- updated yarn to latest (v1) release
- fixed package manager key in package.json to reference correct yarn version
- deleted `.yarnrc.yml`, not used by yarn v1
- updated eslint to 2021 lang version
- removed redundant playwright setup step from pr check workflow
- swap to index digest for app image, docker will target the correct architecture based on the platform being built from
- remove useless yarn commands from dockerfile
- set required image architecture in GHA (on the off chance ubuntu:latest is changed to ARM in the future)

### Why did it change

- `wait-on` was pulling critically vulnerable deps into the toolchain

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-2125](https://govukverify.atlassian.net/browse/LIME-2125)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2125]: https://govukverify.atlassian.net/browse/LIME-2125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ