### PR TITLE
fix: IPS-2290 tune ECS auto-scaling policies for dual-CPU Fargate inst

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -901,7 +901,7 @@ Resources:
           - MetricIntervalLowerBound: 10
             MetricIntervalUpperBound: 15
             ScalingAdjustment: 200 # Scale by 200% of containers
-          - MetricIntervalLowerBound: 15 
+          - MetricIntervalLowerBound: 15
             ScalingAdjustment:
               500 # Scale by 500% of containers
             # Note: CPU can scale greater than 100% in a burst mode

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -930,6 +930,7 @@ Resources:
         # multiple alarm breaches occurring in rapid succession.
         StepAdjustments:
           - MetricIntervalUpperBound: -10
+            MetricIntervalLowerBound: -20
             ScalingAdjustment: -10
           - MetricIntervalLowerBound: -20
             MetricIntervalUpperBound: -20

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -900,14 +900,10 @@ Resources:
             ScalingAdjustment: 100 # Scale by 100% of containers
           - MetricIntervalLowerBound: 10
             MetricIntervalUpperBound: 15
-            ScalingAdjustment: 200 # Scale by 200% of containers 
-          - MetricIntervalLowerBound: 30 
-            MetricIntervalUpperBound: 35 
-            ScalingAdjustment: 300 # Scale by 300% of containers i
-          - MetricIntervalLowerBound: 35 
+            ScalingAdjustment: 200 # Scale by 200% of containers
+          - MetricIntervalLowerBound: 15 
             ScalingAdjustment:
-              500 # Scale by 500% of containers if the metric is breached
-            # with >95% utilisation
+              500 # Scale by 500% of containers
             # Note: CPU can scale greater than 100% in a burst mode
             # on Fargate, so leave the upper bound open
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -74,7 +74,7 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       fargateCPUsize: "2048"
       fargateRAMsize: "4096"
-      minECSCount: 4
+      minECSCount: 3
       maxECSCount: 60
       nodeEnv: "production"
     staging:
@@ -869,7 +869,7 @@ Resources:
         MetricSpecifications:
           - PredefinedMetricPairSpecification:
               PredefinedMetricType: ECSServiceCPUUtilization
-            TargetValue: 60
+            TargetValue: 30
         Mode: ForecastOnly
         SchedulingBufferTime: 600
 
@@ -894,20 +894,17 @@ Resources:
           # Auto Scaling will evaluate all alarm breaches as they occur.
         # A cooldown period is used to protect against over-scaling due to
         # multiple alarm breaches occurring in rapid succession.
-        MinAdjustmentMagnitude: 1
+        MinAdjustmentMagnitude: 3
         StepAdjustments:
-          - MetricIntervalUpperBound: 0 # 60%
-            ScalingAdjustment: 100 # Scale by 100% of containers if the metric is breached
-            # with <60% utilisation
-          - MetricIntervalLowerBound: 0 # 60%
-            MetricIntervalUpperBound: 30 # 90%
-            ScalingAdjustment: 200 # Scale by 200% of containers if the metric is breached
-            # with 80-90% utilisation
-          - MetricIntervalLowerBound: 30 # 90%
-            MetricIntervalUpperBound: 35 # 95%
-            ScalingAdjustment: 300 # Scale by 300% of containers if the metric is breached
-            # with 90-95% utilisation
-          - MetricIntervalLowerBound: 35 # 95%
+          - MetricIntervalUpperBound: 10
+            ScalingAdjustment: 100 # Scale by 100% of containers
+          - MetricIntervalLowerBound: 10
+            MetricIntervalUpperBound: 15
+            ScalingAdjustment: 200 # Scale by 200% of containers 
+          - MetricIntervalLowerBound: 30 
+            MetricIntervalUpperBound: 35 
+            ScalingAdjustment: 300 # Scale by 300% of containers i
+          - MetricIntervalLowerBound: 35 
             ScalingAdjustment:
               500 # Scale by 500% of containers if the metric is breached
             # with >95% utilisation
@@ -936,11 +933,10 @@ Resources:
         # A cooldown period is used to protect against under-scaling due to
         # multiple alarm breaches occurring in rapid succession.
         StepAdjustments:
-          - MetricIntervalUpperBound: -15 # 5%
-            ScalingAdjustment: -90 # Scale down by 90% of containers if the metric is breached
-            # with <5% utilisation
-          - MetricIntervalLowerBound: -15 # 5%
-            MetricIntervalUpperBound: 0 # 20%
+          - MetricIntervalUpperBound: -10
+            ScalingAdjustment: -10
+          - MetricIntervalLowerBound: -20
+            MetricIntervalUpperBound: -20
             ScalingAdjustment:
               -50 # Scale down 50% of containers if the metric is breached
             # with <20% utilisation
@@ -953,7 +949,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref EcsStepScaleOutPolicy
-      AlarmDescription: "EcsClusterOver60PercentCPU"
+      AlarmDescription: "EcsClusterOver30PercentCPU"
       ComparisonOperator: "GreaterThanThreshold"
       DatapointsToAlarm: "1"
       Dimensions:
@@ -967,7 +963,7 @@ Resources:
       Namespace: "AWS/ECS"
       Statistic: "Average"
       Period: "60"
-      Threshold: "60"
+      Threshold: "30"
 
   EcsStepScaleInAlarm:
     DependsOn: ECSAutoScalingTarget
@@ -977,7 +973,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref EcsStepScaleInPolicy
-      AlarmDescription: "EcsClusterUnder60PercentCPU"
+      AlarmDescription: "EcsClusterUnder30PercentCPU"
       ComparisonOperator: "LessThanThreshold"
       DatapointsToAlarm: "5"
       Dimensions:
@@ -991,7 +987,7 @@ Resources:
       Namespace: "AWS/ECS"
       Statistic: "Average"
       Period: "60"
-      Threshold: "20"
+      Threshold: "30"
 
 ####################################################################
 #                                                                  #


### PR DESCRIPTION
Node.js is single-threaded so max CPU utilisation on a 2-vCPU task reports ~50%. Previous thresholds (60%) were unreachable, effectively disabling scaling.

## Proposed changes

### What changed

Changes:

- Reduce scale-out alarm threshold from 60% to 30%
- Reduce predictive scaling target from 60% to 30%
- Lower min instance count from 6 to 3 in build (3 AZs)
- Set MinAdjustmentMagnitude to 3
- Re-tune step adjustments to align with achievable CPU metrics
- Add scale-in steps to return to baseline after traffic subsides
- Now the scaling alarms are triggered at 30% CPU utilisation.

StepAdjustments are also adjusted for when to scale:

- 3 extra instances when CPU is utilised at 30% (30 + 0) instead of 80% (60+20)
- 6 extra instances when CPU is utilised at 40% (30 + 10) and
- 15 extra instances when CPU is utilised at 45% (30 +15)
- and for scale in policies:

- Remove 10% of instances when CPU drops below 20% (30 - 10)
- Remove 50% of instances when CPU drops below 10% (30 - 20)
- MinAdjustmentMagnitude of 3 which is the proposed minimum number of ECS instances will mean during a scaling event at least 3 new instances get created

### Why did it change

Currently the scaling policies are ineffective. They never work and that's because we have a dual CPU fargate instance running node application which is single thread. This means when the application reaches its full capacity we are only at 50% CPU capacity. Current scaling policies scale at 60% therefore we need to bring those values to under 50%.

**Financial benefits:**
Build and prod are set to 6 containers as the min ECS count. 6 containers cost around £500/ month. Reducing this to 3 containers can save up to £250 per month per account.
This means savings of £6k per year or £72k per year across all the CRIs.

We have only reduced the min count to 3 in build to run performance tests and ensure we can meet NFRs before making the same update in prod.

### Issue tracking
[IPS-2290](https://govukverify.atlassian.net/browse/IPS-2290)

## Checklists
Environment variables or secrets
 No environment variables or secrets were added or changed

[IPS-2290]: https://govukverify.atlassian.net/browse/IPS-2290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ