### PR TITLE
LIME-2133 - Passport - Updated Axe Accessibility Coverage

### DIFF
--- a/test/browser/features/wiremock_features/Passport.feature
+++ b/test/browser/features/wiremock_features/Passport.feature
@@ -225,8 +225,73 @@ Feature: Passport CRI - Happy Path and Field Valisation Tests
 
   @QualityGateAccessibilityTest
   @mock-api:passport-success @passport-accessibility
-  Scenario: Passport CRI - Passport Error Page
+  Scenario: Passport CRI - Axe Accessibility Scan - Passport Error Page
     Given I delete the session cookie
     And User clicks on continue
     Then they should see an error page
     Then I run the Axe Accessibility check against the Error entry page
+
+  ########### Axe Accessibility - Error States ##########
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Last Name Validation Error
+    Given I should be on the Passport details entry page Enter your details exactly as they appear on your UK passport – GOV.UK One Login
+    And User enters passport data as a <PassportSubject>
+    And User re-enters last name as <InvalidLastName>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidLastName |
+      | PassportSubjectHappyKenneth |                 |
+
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - First Name Validation Error
+    Given I should be on the Passport details entry page Enter your details exactly as they appear on your UK passport – GOV.UK One Login
+    And User enters passport data as a <PassportSubject>
+    And User re-enters first name as <InvalidFirstName>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidFirstName |
+      | PassportSubjectHappyKenneth |                  |
+
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Date of Birth Validation Error
+    Given I should be on the Passport details entry page Enter your details exactly as they appear on your UK passport – GOV.UK One Login
+    And User enters passport data as a <PassportSubject>
+    And User re-enters day of birth as <InvalidDayOfBirth>
+    And User re-enters month of birth as <InvalidMonthOfBirth>
+    And User re-enters year of birth as <InvalidYearOfBirth>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | PassportSubjectHappyKenneth |                   |                     |                    |
+
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Expiry Date Validation Error
+    Given I should be on the Passport details entry page Enter your details exactly as they appear on your UK passport – GOV.UK One Login
+    And User enters passport data as a <PassportSubject>
+    And User re-enters expiry day as <InvalidExpiryDay>
+    And User re-enters expiry month as <InvalidExpiryMonth>
+    And User re-enters expiry year as <InvalidExpiryYear>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidExpiryDay | InvalidExpiryMonth | InvalidExpiryYear |
+      | PassportSubjectHappyKenneth |                  |                    |                   |
+
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Passport Number Validation Error
+    Given I should be on the Passport details entry page Enter your details exactly as they appear on your UK passport – GOV.UK One Login
+    And User enters passport data as a <PassportSubject>
+    Then User re-enters passportNumber as <InvalidPassportNumber>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidPassportNumber |
+      | PassportSubjectHappyKenneth |                       |

--- a/test/browser/features/wiremock_features/WelshPassport.feature
+++ b/test/browser/features/wiremock_features/WelshPassport.feature
@@ -24,6 +24,7 @@ Feature: Passport CRI - Welsh Language Tests
   Scenario: Passport CRI - Check error page following cookie deletion
     Given I delete the session cookie
     And User clicks on continue
+    Then they should see a Welsh error page
     Then I see the heading Mae’n ddrwg gennym, mae problem
     And I see Contact the One Login team link reads Cysylltu â thîm GOV.UK One Login (agor mewn tab newydd)
     And I assert the link on the error page is correct and live
@@ -146,3 +147,80 @@ Feature: Passport CRI - Welsh Language Tests
     Examples:
       | PassportSubject             | InvalidPassportNumber |
       | PassportSubjectHappyKenneth | 5566778               |
+
+  ########### Axe Accessibility ##########
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility @language-regression
+  Scenario: Passport CRI - Axe Accessibility Scan - Welsh Passport Details Page
+    Given I run the Axe Accessibility check against the Passport details entry page
+    And User enters passport data as a PassportSubjectHappyKenneth
+    When User clicks on continue
+
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility @language-regression
+  Scenario: Passport CRI - Axe Accessibility Scan - Welsh Error Page
+    Given I delete the session cookie
+    And User clicks on continue
+    Then they should see a Welsh error page
+    And I see the heading Mae’n ddrwg gennym, mae problem
+    Then I run the Axe Accessibility check against the Error entry page
+
+  ########### Axe Accessibility - Error States ##########
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility @language-regression
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Welsh Last Name Validation Error
+    And User enters passport data as a <PassportSubject>
+    And User re-enters last name as <InvalidLastName>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidLastName |
+      | PassportSubjectHappyKenneth |                 |
+
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility @language-regression
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Welsh First Name Validation Error
+    And User enters passport data as a <PassportSubject>
+    And User re-enters first name as <InvalidFirstName>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidFirstName |
+      | PassportSubjectHappyKenneth |                  |
+
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility @language-regression
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Welsh Date of Birth Validation Error
+    And User enters passport data as a <PassportSubject>
+    And User re-enters day of birth as <InvalidDayOfBirth>
+    And User re-enters month of birth as <InvalidMonthOfBirth>
+    And User re-enters year of birth as <InvalidYearOfBirth>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | PassportSubjectHappyKenneth |                   |                     |                    |
+
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility @language-regression
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Welsh Expiry Date Validation Error
+    And User enters passport data as a <PassportSubject>
+    And User re-enters expiry day as <InvalidExpiryDay>
+    And User re-enters expiry month as <InvalidExpiryMonth>
+    And User re-enters expiry year as <InvalidExpiryYear>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidExpiryDay | InvalidExpiryMonth | InvalidExpiryYear |
+      | PassportSubjectHappyKenneth |                  |                    |                   |
+
+  @QualityGateAccessibilityTest
+  @mock-api:passport-success @passport-accessibility @language-regression
+  Scenario Outline: Passport CRI - Axe Accessibility Scan - Welsh Passport Number Validation Error
+    And User enters passport data as a <PassportSubject>
+    Then User re-enters passportNumber as <InvalidPassportNumber>
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the Passport details entry page
+    Examples:
+      | PassportSubject             | InvalidPassportNumber |
+      | PassportSubjectHappyKenneth |                       |

--- a/test/browser/pages/wiremock_pages/error.js
+++ b/test/browser/pages/wiremock_pages/error.js
@@ -10,6 +10,10 @@ module.exports = class PlaywrightDevPage {
     return "    Sorry, there is a problem";
   }
 
+  getSomethingWentWrongMessagWelsh() {
+    return "    Mae’n ddrwg gennym, mae problem";
+  }
+
   getErrorTitle() {
     return this.page.textContent('[data-page="error"]');
   }

--- a/test/browser/step_definitions/wiremock_steps/errors.js
+++ b/test/browser/step_definitions/wiremock_steps/errors.js
@@ -14,6 +14,14 @@ Then("they should see an error page", async function () {
   );
 });
 
+Then("they should see a Welsh error page", async function () {
+  const errorPage = new ErrorPage(this.page);
+  const errorTitle = await errorPage.getErrorTitle();
+  expect(errorTitle.trim()).to.equal(
+    errorPage.getSomethingWentWrongMessagWelsh().trim()
+  );
+});
+
 Then(
   "I run the Axe Accessibility check against the Error entry page",
   async function () {

--- a/test/browser/step_definitions/wiremock_steps/passport.js
+++ b/test/browser/step_definitions/wiremock_steps/passport.js
@@ -20,7 +20,7 @@ Given(
   /^I run the Axe Accessibility check against the Passport details entry page$/,
   async function () {
     const results = await new AxeBuilder({ page: this.page })
-      .withTags(["wcag22aa"])
+      .withTags(["wcag22aa", "best-practice"])
       .analyze();
 
     expect(results.violations).to.be.empty;


### PR DESCRIPTION
Updated the Coverage to include:
best-practice tag
Welsh Page tests
Page Error tests

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

best-practice tag added to the Axe Accessibility Check Step
Welsh Page tests added with Axe Accessibility Coverage
Page Error tests added with Axe Accessibility Coverage i.e. invalid data entered on the details page error message boxes

### Why did it change

To ensure maximum coverage of accessibility with the axe-core tool

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-2133](https://govukverify.atlassian.net/browse/LIME-2133)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
<img width="384" height="76" alt="image" src="https://github.com/user-attachments/assets/89ccd19d-8636-4e6b-aebb-8630b7fcd274" />


[LIME-2133]: https://govukverify.atlassian.net/browse/LIME-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ