### PR TITLE
LIME-2380 Upgrade frontend-analytics and di-ipv-cri-common-express

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3.1044.0",
-        "@govuk-one-login/di-ipv-cri-common-express": "15.1.1",
-        "@govuk-one-login/frontend-analytics": "4.0.7",
+        "@govuk-one-login/di-ipv-cri-common-express": "15.2.0",
+        "@govuk-one-login/frontend-analytics": "4.2.0",
         "@govuk-one-login/frontend-device-intelligence": "1.1.0",
         "@govuk-one-login/frontend-language-toggle": "1.1.0",
         "@govuk-one-login/frontend-passthrough-headers": "1.3.2",
@@ -1388,9 +1388,9 @@
       }
     },
     "node_modules/@govuk-one-login/di-ipv-cri-common-express": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-15.1.1.tgz",
-      "integrity": "sha512-a0v8wu0aK6PlrPVGEUnAigLFCU1Yohi3cN96ldiOf81kSRgNxjFMB1s9di5ElsaU2tsDj1Gp+r3RfQTkTZl5fQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-15.2.0.tgz",
+      "integrity": "sha512-bLst9yO6XUZWLO7M7EiO+fVz5Wk60leRs2PLp9P1uwOmMe7XxSNiLhZ9MLiUSQ4HXDrm/x5t6IiNOPilkF+KeQ==",
       "license": "MIT",
       "dependencies": {
         "async": "3.2.6",
@@ -1459,9 +1459,9 @@
       }
     },
     "node_modules/@govuk-one-login/frontend-analytics": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-4.0.7.tgz",
-      "integrity": "sha512-G78BF00pluhlxATx8Gc3/wejDPg2yf2wMQPCIV6l0uotuh0wb81Qw+j7IN+rsDNMzwvtKxFpAmjKcfxJZPXh7w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@govuk-one-login/frontend-analytics/-/frontend-analytics-4.2.0.tgz",
+      "integrity": "sha512-6CnKHdzZkgtFLnHe0NQM1atgq6oV1KMKF8eBewuG5hvW2Lio0+otr/18pw0uXimyJs0uz0nPdvdM2Fh+9WYrRw==",
       "license": "MIT",
       "dependencies": {
         "loglevel": "^1.9.2"

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "3.1044.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "15.1.1",
-    "@govuk-one-login/frontend-analytics": "4.0.7",
+    "@govuk-one-login/di-ipv-cri-common-express": "15.2.0",
+    "@govuk-one-login/frontend-analytics": "4.2.0",
     "@govuk-one-login/frontend-device-intelligence": "1.1.0",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.3.2",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

  - bump govuk-one-login/frontend-analytics
  - bump govuk-one-login/di-ipv-cri-common-express

### Why did it change

  - frontend-analytics to fix a logging issue
  - common-express to fix a redirect being triggered due to missing static resources

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-2380](https://govukverify.atlassian.net/browse/LIME-2380)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2380]: https://govukverify.atlassian.net/browse/LIME-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ